### PR TITLE
add include and library folder on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(magent)
 IF (APPLE)
     set(CMAKE_CXX_COMPILER "/usr/local/opt/llvm/bin/clang++")
     link_directories("/usr/local/opt/llvm/lib")
+    include_directories( "/usr/local/include" )
+    link_directories("/usr/local/lib/")
 ENDIF()
 
 file(GLOB autopilot_sources src/*.cc src/gridworld/*.cc src/discrete_snake/*.cc src/utility/*.cc)

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,11 @@ fi
 mkdir -p build
 cd build
 cmake ..
-make -j $(nproc)
+#make -j $(nproc)
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    # Linux
+    make -j `nproc`
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    make -j `sysctl -n hw.ncpu`
+fi


### PR DESCRIPTION
编译过程中找不到头文件和库，没有添加路径
macOS High Sierra 版本 10.13.1