### PR TITLE
Update link to maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## This project is no longer maintained
 
-Please see https://github.com/PettingZoo-Team/MAgent for a maintained fork of this project that's installable with pip.
+Please see https://github.com/Farama-Foundation/MAgent for a maintained fork of this project that's installable with pip.
 
 ## MAgent
 


### PR DESCRIPTION
Awhile ago we renamed the PettingZoo Team org to the Farama Foundation. This old link still works via redirect, but this removes the redirect since it's confused at least two people.